### PR TITLE
Fixes issue where directory names are uppercase in MTP mount but lowercase in update file. 

### DIFF
--- a/GSL/update.py
+++ b/GSL/update.py
@@ -82,10 +82,11 @@ class Update:
                 #try to check if uppercase director exists
                 new_dir_path = os.path.join(path_dir, os.path.basename(current_path).upper())
                 if not os.path.isdir(new_dir_path):
-                    # non existing child directory path found in update
-                    # make new path as it is, as this comes from software update
+                    # non existing child directory path found in update or lowercase name is already there
                     new_dir_path = os.path.join(path_dir, os.path.basename(current_path))
-                    os.mkdir(new_dir_path)
+                    if not os.path.isdir(new_dir_path):
+                        # make new path as it is, as this comes from software update
+                        os.mkdir(new_dir_path)
                 new_current_path =  os.path.join(new_dir_path, path_parts.pop())
                 return self.fix_path_case(new_current_path, path_parts)
             else:


### PR DESCRIPTION
For example `unit_filepath` was `Garmin/Text/french.ln4` in the update but then on my MTP mount it was found under `GARMIN/TEXT/french.ln4`

This should also create non existing directory like `GARMIN/ExtData` which was needed for some files from update.

